### PR TITLE
fix: image path in openai-realtime-console-example's readme

### DIFF
--- a/9-realtime/openai-realtime-console-example/README.md
+++ b/9-realtime/openai-realtime-console-example/README.md
@@ -7,7 +7,7 @@ that acts as a **Reference Client** (for browser and Node.js) and
 [`/src/lib/wavtools`](./src/lib/wavtools) which allows for simple audio
 management in the browser.
 
-<img src="/readme/realtime-console-demo.png" width="800" />
+<img src="./readme/realtime-console-demo.png" width="800" />
 
 # Starting the console
 


### PR DESCRIPTION
Fixes image path in openai-realtime-console-example's readme