### PR TITLE
Fix Supply Co realtime response lifecycle

### DIFF
--- a/25-realtime-2/README.md
+++ b/25-realtime-2/README.md
@@ -513,6 +513,15 @@ ENABLE_REALTIME_COST_TRACES=1
 
 Keep generated traces local. Do not commit them.
 
+Supply Co. also keeps a compact in-browser Realtime lifecycle log for debugging response timing issues. In the browser console:
+
+```js
+window.__supplyRealtimeDebug.get()
+window.__supplyRealtimeDebug.clear()
+```
+
+The log is stored in `localStorage` under `supply-realtime-debug-log-v1` and records event metadata such as response ids, item ids, call ids, tool names, gate decisions, and error messages. It intentionally omits raw transcripts and tool output payloads.
+
 ## Assets
 
 Supply Co. and MetricLoop are fictional demo brands. Runtime product imagery under `public/demo-assets/generated` is synthetic demo imagery; no third-party brand assets are intentionally included.

--- a/25-realtime-2/src/agent/supplyPrompt.test.ts
+++ b/25-realtime-2/src/agent/supplyPrompt.test.ts
@@ -32,6 +32,12 @@ describe('Supply realtime prompt contract', () => {
     expect(SUPPLY_REALTIME_INSTRUCTIONS).toContain('avoid repeating the full product title');
   });
 
+  it('requires direct requirement language instead of hedged shopping guidance', () => {
+    expect(SUPPLY_REALTIME_INSTRUCTIONS).toContain('Use direct shopping guidance for requirements');
+    expect(SUPPLY_REALTIME_INSTRUCTIONS).toContain('Say "You need a tent"');
+    expect(SUPPLY_REALTIME_INSTRUCTIONS.toLowerCase()).not.toMatch(/\busually\b|\btypically\b|\bgenerally\b|\bnormally\b|\bin most cases\b/);
+  });
+
   it('exposes weather web search for trip-risk follow-ups', () => {
     expect(SUPPLY_REALTIME_TOOLS.map((tool) => tool.name)).toContain('search_weather_web');
     expect(SUPPLY_REALTIME_INSTRUCTIONS).toContain('search_weather_web');

--- a/25-realtime-2/src/agent/supplyPrompt.ts
+++ b/25-realtime-2/src/agent/supplyPrompt.ts
@@ -33,6 +33,7 @@ You are Supply Co. Shopping Assistant for a shopping session on Supply Co.
 
 # Shopping Behavior
 - If the shopper says they are going hiking and asks what they need, call get_hiking_needs and suggest tent and hiking shoes first. Mention that their daypack, trail socks, and insulated bottle are already covered, then ask which item to look for.
+- Use direct shopping guidance for requirements. Say "You need a tent" instead of hedged wording for essential trip gear.
 - Search only after the shopper confirms the item or clearly asks you to search.
 - You may apply filters when the shopper states a preference like price, free shipping, Supply-ready items, rating, or shoe size.
 - Treat shopper budgets as plain dollar amounts and apply them directly as max price filters, even when the budget is broad.
@@ -128,7 +129,7 @@ Prefer 3-8 words and never exceed 12 words.
 - If the shopper asks for checkout or payment, explain briefly that you can review the cart but cannot complete purchase.
 
 # Verbosity
-- Keep final spoken answers short: usually 1-2 sentences.
+- Keep final spoken answers short: 1-2 sentences.
 - After naming a product once, avoid repeating the full product title. Use casual follow-ups like "this one", "the tent", "those shoes", or "it" when the reference is clear.
 - Ask one clear next question when a choice is needed.
 `.trim();

--- a/25-realtime-2/src/agent/supplyRealtimeDebugLog.test.ts
+++ b/25-realtime-2/src/agent/supplyRealtimeDebugLog.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { createSupplyRealtimeDebugEntry } from './supplyRealtimeDebugLog';
+
+describe('Supply realtime debug log', () => {
+  it('keeps lifecycle metadata without storing raw transcript or tool output', () => {
+    const entry = createSupplyRealtimeDebugEntry('server', {
+      type: 'response.done',
+      response: {
+        id: 'resp_123',
+        output: [
+          {
+            id: 'item_1',
+            type: 'function_call',
+            call_id: 'call_1',
+            name: 'search_products',
+            arguments: '{"query":"private words"}',
+          },
+        ],
+      },
+      transcript: 'private transcript',
+      delta: 'private delta',
+    });
+
+    expect(entry).toMatchObject({
+      direction: 'server',
+      type: 'response.done',
+      responseId: 'resp_123',
+      responseOutputCount: 1,
+      responseFunctionCalls: [{ itemId: 'item_1', callId: 'call_1', toolName: 'search_products' }],
+    });
+    expect(JSON.stringify(entry)).not.toContain('private transcript');
+    expect(JSON.stringify(entry)).not.toContain('private delta');
+    expect(JSON.stringify(entry)).not.toContain('private words');
+  });
+
+  it('records function_call_output metadata without persisting output payloads', () => {
+    const entry = createSupplyRealtimeDebugEntry('client', {
+      type: 'conversation.item.create',
+      item: {
+        type: 'function_call_output',
+        call_id: 'call_2',
+        output: '{"products":[{"title":"private product"}]}',
+      },
+    });
+
+    expect(entry).toMatchObject({
+      direction: 'client',
+      type: 'conversation.item.create',
+      itemType: 'function_call_output',
+      callId: 'call_2',
+      outputLength: 42,
+    });
+    expect(JSON.stringify(entry)).not.toContain('private product');
+  });
+});

--- a/25-realtime-2/src/agent/supplyRealtimeDebugLog.ts
+++ b/25-realtime-2/src/agent/supplyRealtimeDebugLog.ts
@@ -1,0 +1,152 @@
+export const SUPPLY_REALTIME_DEBUG_LOG_KEY = 'supply-realtime-debug-log-v1';
+const MAX_SUPPLY_REALTIME_DEBUG_ENTRIES = 500;
+
+export type SupplyRealtimeDebugDirection = 'client' | 'server' | 'internal';
+
+interface UnknownRecord {
+  [key: string]: unknown;
+}
+
+export interface SupplyRealtimeDebugEntry {
+  ts: string;
+  direction: SupplyRealtimeDebugDirection;
+  type: string;
+  note?: string;
+  responseId?: string;
+  itemId?: string;
+  itemType?: string;
+  callId?: string;
+  toolName?: string;
+  phase?: string;
+  errorMessage?: string;
+  responseOutputCount?: number;
+  responseFunctionCalls?: Array<{
+    itemId?: string;
+    callId?: string;
+    toolName?: string;
+  }>;
+  outputLength?: number;
+  gateDecision?: string;
+  reason?: string;
+}
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isDebugEntry(value: unknown): value is SupplyRealtimeDebugEntry {
+  return isRecord(value) && typeof value.ts === 'string' && typeof value.direction === 'string' && typeof value.type === 'string';
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value ? value : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function getResponse(event: UnknownRecord) {
+  return isRecord(event.response) ? event.response : undefined;
+}
+
+function getItem(event: UnknownRecord) {
+  return isRecord(event.item) ? event.item : undefined;
+}
+
+function getError(event: UnknownRecord) {
+  return isRecord(event.error) ? event.error : undefined;
+}
+
+function getResponseFunctionCalls(response: UnknownRecord | undefined) {
+  const output = Array.isArray(response?.output) ? response.output : [];
+  return output
+    .filter(isRecord)
+    .filter((item) => item.type === 'function_call')
+    .map((item) => ({
+      itemId: stringValue(item.id),
+      callId: stringValue(item.call_id),
+      toolName: stringValue(item.name),
+    }));
+}
+
+export function createSupplyRealtimeDebugEntry(
+  direction: SupplyRealtimeDebugDirection,
+  event: unknown,
+  metadata: Partial<Pick<SupplyRealtimeDebugEntry, 'note' | 'gateDecision' | 'reason'>> = {},
+): SupplyRealtimeDebugEntry {
+  const record = isRecord(event) ? event : {};
+  const item = getItem(record);
+  const response = getResponse(record);
+  const error = getError(record);
+  const responseFunctionCalls = getResponseFunctionCalls(response);
+  const output = item?.output;
+
+  return {
+    ts: new Date().toISOString(),
+    direction,
+    type: stringValue(record.type) ?? metadata.note ?? 'unknown',
+    ...metadata,
+    responseId: stringValue(response?.id) ?? stringValue(record.response_id),
+    itemId: stringValue(record.item_id) ?? stringValue(item?.id),
+    itemType: stringValue(item?.type),
+    callId: stringValue(record.call_id) ?? stringValue(item?.call_id),
+    toolName: stringValue(item?.name) ?? stringValue(record.name),
+    phase: stringValue(item?.phase),
+    errorMessage: stringValue(error?.message) ?? stringValue(record.message),
+    responseOutputCount: Array.isArray(response?.output) ? response.output.length : undefined,
+    responseFunctionCalls: responseFunctionCalls.length ? responseFunctionCalls : undefined,
+    outputLength: typeof output === 'string' ? output.length : numberValue(record.outputLength),
+  };
+}
+
+export function readSupplyRealtimeDebugLog(): SupplyRealtimeDebugEntry[] {
+  const storage = globalThis.localStorage;
+  if (!storage) return [];
+
+  try {
+    const parsed = JSON.parse(storage.getItem(SUPPLY_REALTIME_DEBUG_LOG_KEY) ?? '[]');
+    return Array.isArray(parsed) ? parsed.filter(isDebugEntry) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function appendSupplyRealtimeDebugLog(entry: SupplyRealtimeDebugEntry) {
+  try {
+    const next = [...readSupplyRealtimeDebugLog(), entry].slice(-MAX_SUPPLY_REALTIME_DEBUG_ENTRIES);
+    globalThis.localStorage?.setItem(SUPPLY_REALTIME_DEBUG_LOG_KEY, JSON.stringify(next));
+  } catch {
+    // Debug logging must never affect the realtime session.
+  }
+
+  globalThis.console?.debug?.('[SupplyRealtime]', entry);
+}
+
+export function logSupplyRealtimeEvent(
+  direction: SupplyRealtimeDebugDirection,
+  event: unknown,
+  metadata?: Partial<Pick<SupplyRealtimeDebugEntry, 'note' | 'gateDecision' | 'reason'>>,
+) {
+  appendSupplyRealtimeDebugLog(createSupplyRealtimeDebugEntry(direction, event, metadata));
+}
+
+export function clearSupplyRealtimeDebugLog() {
+  globalThis.localStorage?.removeItem(SUPPLY_REALTIME_DEBUG_LOG_KEY);
+}
+
+export function installSupplyRealtimeDebugHelpers() {
+  const target = globalThis as typeof globalThis & {
+    __supplyRealtimeDebug?: {
+      key: string;
+      get: () => SupplyRealtimeDebugEntry[];
+      clear: () => void;
+    };
+  };
+
+  target.__supplyRealtimeDebug ??= {
+    key: SUPPLY_REALTIME_DEBUG_LOG_KEY,
+    get: readSupplyRealtimeDebugLog,
+    clear: clearSupplyRealtimeDebugLog,
+  };
+}

--- a/25-realtime-2/src/agent/supplyResponseGate.test.ts
+++ b/25-realtime-2/src/agent/supplyResponseGate.test.ts
@@ -39,4 +39,16 @@ describe('Supply response gate', () => {
     expect(gate.markResponseDone()).toEqual({ shouldCreateResponse: true, reason: 'tool' });
     expect(gate.markResponseDone()).toEqual({ shouldCreateResponse: false });
   });
+
+  it('waits for all pending tool outputs when response.done arrives first', () => {
+    const gate = createSupplyResponseGate();
+
+    gate.markResponseCreated();
+    gate.markToolCallStarted('call_1');
+    gate.markToolCallStarted('call_2');
+
+    expect(gate.markResponseDone()).toEqual({ shouldCreateResponse: false });
+    expect(gate.requestResponseForToolOutput('call_1')).toBe(false);
+    expect(gate.requestResponseForToolOutput('call_2')).toBe(true);
+  });
 });

--- a/25-realtime-2/src/agent/supplyResponseGate.ts
+++ b/25-realtime-2/src/agent/supplyResponseGate.ts
@@ -11,9 +11,9 @@ export interface SupplyResponseGate {
   markResponseCreated(): void;
   markResponseRequestFailed(): void;
   markResponseDone(): SupplyResponseGateDrain;
-  markToolCallStarted(): void;
-  markToolCallFinished(): void;
-  requestResponseForToolOutput(): boolean;
+  markToolCallStarted(callId?: string): void;
+  markToolCallFinished(callId?: string): void;
+  requestResponseForToolOutput(callId?: string): boolean;
   requestResponseForUserTurn(): boolean;
   reset(): void;
 }
@@ -28,7 +28,6 @@ function toSupplyDrain(request: RealtimeResponseRequest): SupplyResponseGateDrai
 
 export function createSupplyResponseGate(): SupplyResponseGate {
   const controller = createRealtimeResponseController();
-  let toolCallActive = false;
 
   return {
     markResponseCreated() {
@@ -40,27 +39,21 @@ export function createSupplyResponseGate(): SupplyResponseGate {
     markResponseDone() {
       return toSupplyDrain(controller.markResponseDone());
     },
-    markToolCallStarted() {
-      toolCallActive = true;
-      controller.beginToolCall();
+    markToolCallStarted(callId?: string) {
+      controller.beginToolCall(callId);
     },
-    markToolCallFinished() {
-      if (!toolCallActive) return;
-      toolCallActive = false;
-      controller.completeToolCall();
+    markToolCallFinished(callId?: string) {
+      controller.completeToolCall(callId);
     },
-    requestResponseForToolOutput() {
-      if (toolCallActive) {
-        toolCallActive = false;
-        controller.completeToolCall();
-      }
+    requestResponseForToolOutput(callId?: string) {
+      const completedTool = controller.completeToolCall(callId);
+      if (completedTool.shouldCreateResponse) return true;
       return controller.requestToolContinuation().shouldCreateResponse;
     },
     requestResponseForUserTurn() {
       return controller.requestTextTurn('supply typed turn').shouldCreateResponse;
     },
     reset() {
-      toolCallActive = false;
       controller.reset();
     },
   };

--- a/25-realtime-2/src/agent/useSupplyRealtime.ts
+++ b/25-realtime-2/src/agent/useSupplyRealtime.ts
@@ -16,6 +16,10 @@ import {
   SUPPLY_REALTIME_MODEL,
   SUPPLY_REALTIME_REASONING,
 } from './supplyRealtimeConfig';
+import {
+  installSupplyRealtimeDebugHelpers,
+  logSupplyRealtimeEvent,
+} from './supplyRealtimeDebugLog';
 import { createSupplyResponseGate } from './supplyResponseGate';
 import type {
   AddToCartRequest,
@@ -72,6 +76,7 @@ interface ServerEvent {
     };
   };
   response?: {
+    id?: string;
     usage?: {
       total_tokens?: number;
       input_tokens?: number;
@@ -292,9 +297,17 @@ export function useSupplyRealtime() {
     agentRef.current = agent;
   }, [agent]);
 
+  useEffect(() => {
+    installSupplyRealtimeDebugHelpers();
+  }, []);
+
   const sendClientEvent = useCallback((event: unknown) => {
     const dataChannel = dataChannelRef.current;
-    if (!dataChannel || dataChannel.readyState !== 'open') return false;
+    if (!dataChannel || dataChannel.readyState !== 'open') {
+      logSupplyRealtimeEvent('client', event, { gateDecision: 'not_sent', reason: 'data_channel_not_open' });
+      return false;
+    }
+    logSupplyRealtimeEvent('client', event, { gateDecision: 'sent' });
     dataChannel.send(JSON.stringify(event));
     return true;
   }, []);
@@ -302,18 +315,27 @@ export function useSupplyRealtime() {
   const sendResponseCreate = useCallback(() => {
     const sent = sendClientEvent({ type: 'response.create' });
     if (!sent) {
+      logSupplyRealtimeEvent('internal', { type: 'supply.response_create_failed' });
       responseGateRef.current.markResponseRequestFailed();
     }
     return sent;
   }, [sendClientEvent]);
 
-  const requestResponseForToolOutput = useCallback(() => {
-    if (!responseGateRef.current.requestResponseForToolOutput()) return false;
+  const requestResponseForToolOutput = useCallback((callId?: string) => {
+    if (!responseGateRef.current.requestResponseForToolOutput(callId)) {
+      logSupplyRealtimeEvent('internal', { type: 'supply.tool_continuation_deferred', call_id: callId });
+      return false;
+    }
+    logSupplyRealtimeEvent('internal', { type: 'supply.tool_continuation_allowed', call_id: callId });
     return sendResponseCreate();
   }, [sendResponseCreate]);
 
   const requestResponseForUserTurn = useCallback(() => {
-    if (!responseGateRef.current.requestResponseForUserTurn()) return false;
+    if (!responseGateRef.current.requestResponseForUserTurn()) {
+      logSupplyRealtimeEvent('internal', { type: 'supply.user_turn_deferred' });
+      return false;
+    }
+    logSupplyRealtimeEvent('internal', { type: 'supply.user_turn_allowed' });
     return sendResponseCreate();
   }, [sendResponseCreate]);
 
@@ -538,7 +560,13 @@ export function useSupplyRealtime() {
 
   const runFunctionCall = useCallback(
     async (itemId: string, call: PendingFunctionCall) => {
-      responseGateRef.current.markToolCallStarted();
+      logSupplyRealtimeEvent('internal', {
+        type: 'supply.tool_started',
+        item_id: itemId,
+        call_id: call.callId,
+        name: call.name,
+      });
+      responseGateRef.current.markToolCallStarted(call.callId);
       removePrematureAssistantMessagesForToolTurn();
       const isAddToCartCall = call.name === 'add_to_cart';
       const relevantAssistantText = `${assistantTextBeforeCurrentTurnRef.current} ${lastAssistantTextRef.current}`;
@@ -626,7 +654,14 @@ export function useSupplyRealtime() {
             output: JSON.stringify(output),
           },
         });
-        requestResponseForToolOutput();
+        logSupplyRealtimeEvent('internal', {
+          type: 'supply.tool_output_sent',
+          item_id: itemId,
+          call_id: call.callId,
+          name: call.name,
+          outputLength: JSON.stringify(output).length,
+        });
+        requestResponseForToolOutput(call.callId);
         if (shouldShowToolActivity) {
           updateToolActivity(itemId, {
             status: 'done',
@@ -643,12 +678,20 @@ export function useSupplyRealtime() {
             output: JSON.stringify(output),
           },
         });
-        requestResponseForToolOutput();
+        logSupplyRealtimeEvent('internal', {
+          type: 'supply.tool_output_sent',
+          item_id: itemId,
+          call_id: call.callId,
+          name: call.name,
+          outputLength: JSON.stringify(output).length,
+          reason: 'tool_failed',
+        });
+        requestResponseForToolOutput(call.callId);
         if (shouldShowToolActivity) {
           updateToolActivity(itemId, { status: 'failed' });
         }
       } finally {
-        responseGateRef.current.markToolCallFinished();
+        responseGateRef.current.markToolCallFinished(call.callId);
       }
     },
     [
@@ -662,6 +705,8 @@ export function useSupplyRealtime() {
 
   const handleServerEvent = useCallback(
     (event: ServerEvent) => {
+      logSupplyRealtimeEvent('server', event);
+
       if (event.type === 'session.updated') {
         setStatus('listening');
         return;
@@ -780,6 +825,12 @@ export function useSupplyRealtime() {
           usage: event.response?.usage,
         });
         const pendingResponse = responseGateRef.current.markResponseDone();
+        logSupplyRealtimeEvent('internal', {
+          type: 'supply.response_done_gate',
+          response_id: event.response?.id,
+          reason: pendingResponse.reason,
+          gateDecision: pendingResponse.shouldCreateResponse ? 'create_response' : 'no_response',
+        });
         if (pendingResponse.shouldCreateResponse) {
           const sent = sendResponseCreate();
           setStatus(sent ? 'speaking' : 'listening');

--- a/25-realtime-2/src/realtime/realtimeResponseController.test.ts
+++ b/25-realtime-2/src/realtime/realtimeResponseController.test.ts
@@ -66,6 +66,23 @@ describe('createRealtimeResponseController', () => {
     });
   });
 
+  it('waits for every pending tool output before continuing after response.done', () => {
+    const controller = createRealtimeResponseController();
+
+    expect(controller.requestTextTurn('Find tents')).toMatchObject({ shouldCreateResponse: true });
+    controller.markResponseCreated('resp_1');
+    controller.beginToolCall('call_1');
+    controller.beginToolCall('call_2');
+
+    expect(controller.markResponseDone('resp_1')).toEqual({ shouldCreateResponse: false });
+    expect(controller.requestToolContinuation()).toEqual({ shouldCreateResponse: false });
+    expect(controller.completeToolCall('call_1')).toEqual({ shouldCreateResponse: false });
+    expect(controller.completeToolCall('call_2')).toEqual({
+      shouldCreateResponse: true,
+      reason: 'tool',
+    });
+  });
+
   it('queues typed turns while a response is active', () => {
     const controller = createRealtimeResponseController();
 

--- a/25-realtime-2/src/realtime/realtimeResponseController.ts
+++ b/25-realtime-2/src/realtime/realtimeResponseController.ts
@@ -26,12 +26,17 @@ export function createRealtimeResponseController(): RealtimeResponseController {
   let waitingForTranscript = false;
   let responseRequested = false;
   let responseActive = false;
-  let toolCallActive = false;
+  const activeToolCallIds = new Set<string>();
+  let anonymousToolCallCount = 0;
   let continuationPending = false;
   let queuedTurnText: string | null = null;
 
+  function hasActiveToolCalls() {
+    return activeToolCallIds.size > 0 || anonymousToolCallCount > 0;
+  }
+
   function canCreateResponse() {
-    return !responseRequested && !responseActive && !toolCallActive;
+    return !responseRequested && !responseActive && !hasActiveToolCalls();
   }
 
   function requestResponse(reason: RealtimeResponseRequestReason, text?: string): RealtimeResponseRequest {
@@ -49,7 +54,7 @@ export function createRealtimeResponseController(): RealtimeResponseController {
   }
 
   function drainPendingResponse(): RealtimeResponseRequest {
-    if (toolCallActive) return noResponse;
+    if (hasActiveToolCalls()) return noResponse;
     if (responseRequested || responseActive) return noResponse;
 
     if (continuationPending) {
@@ -103,11 +108,19 @@ export function createRealtimeResponseController(): RealtimeResponseController {
       responseActive = false;
       return drainPendingResponse();
     },
-    beginToolCall() {
-      toolCallActive = true;
+    beginToolCall(callId?: string) {
+      if (callId) {
+        activeToolCallIds.add(callId);
+      } else {
+        anonymousToolCallCount += 1;
+      }
     },
-    completeToolCall() {
-      toolCallActive = false;
+    completeToolCall(callId?: string) {
+      if (callId) {
+        activeToolCallIds.delete(callId);
+      } else {
+        anonymousToolCallCount = Math.max(0, anonymousToolCallCount - 1);
+      }
       return drainPendingResponse();
     },
     requestToolContinuation() {
@@ -123,7 +136,8 @@ export function createRealtimeResponseController(): RealtimeResponseController {
       waitingForTranscript = false;
       responseRequested = false;
       responseActive = false;
-      toolCallActive = false;
+      activeToolCallIds.clear();
+      anonymousToolCallCount = 0;
       continuationPending = false;
       queuedTurnText = null;
     },

--- a/25-realtime-2/vite.config.ts
+++ b/25-realtime-2/vite.config.ts
@@ -421,4 +421,7 @@ function supplyRealtimeApiPlugin(): PluginOption {
 
 export default defineConfig({
   plugins: [react(), supplyRealtimeApiPlugin()],
+  preview: {
+    allowedHosts: ['voice-shopping-metricloop.app.openai.org'],
+  },
 });


### PR DESCRIPTION
## Summary
- Track Supply Co pending tool calls by call id so response continuations wait for every tool output.
- Add sanitized in-browser lifecycle logging via window.__supplyRealtimeDebug for debugging response.create timing issues.
- Tighten the Supply Co prompt to use direct requirement language and avoid "usually" for shopping requirements.

## Validation
- App Garden deployed: https://voice-shopping-metricloop.app.openai.org (deployment 78833)
- App Garden runtime logs: pod Running, restarts=0, vite preview serving on the App Garden port.
- npm test
- npm run build
- Rendered smoke check for / and /metricloop from the clean Build Hours worktree; both loaded with no horizontal overflow, Supply debug helper present, and MetricLoop activation investigation visible.

## Notes
- The deployed App Garden URL is auth-gated, so Playwright without the authenticated profile reached Microsoft sign-in. The deployed runtime was verified through App Garden status/logs plus the local rendered check from the same Build Hours package.